### PR TITLE
Fix `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "repository": "github:opencast/eslint-config-ts-react",
   "license": "CC0-1.0",
   "main": "config.js",
-  "license": "MIT",
   "peerDependencies": {
     "eslint": ">= 8",
     "eslint-plugin-react": ">= 7",
@@ -13,6 +12,6 @@
     "@typescript-eslint/eslint-plugin": ">= 5"
   },
   "dependencies": {
-    "@typescript-eslint/parser": "^5.59.9"
+    "@typescript-eslint/parser": ">= 5"
   }
 }


### PR DESCRIPTION
The `license` key was duplicated. I picked the one that's explicitly mentioned in the `README`.

Also the version ranges of `@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser` can lead to incompatibilities: `eslint-plugin >= 5` currently resolves to `6.4.0`, which is not compatible with `parser <= 5`.