### PR TITLE
Update typescript-eslint/eslint-plugin to 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "eslint": ">= 8",
     "eslint-plugin-react": ">= 7",
     "eslint-plugin-react-hooks": ">= 4",
-    "@typescript-eslint/eslint-plugin": ">= 5"
+    "@typescript-eslint/eslint-plugin": ">= 6"
   },
   "dependencies": {
-    "@typescript-eslint/parser": ">= 5"
+    "@typescript-eslint/parser": ">= 6"
   }
 }


### PR DESCRIPTION
Update dependencies to new major version. Tested with Opencast Editor.

I became aware of this because the Editor would spit out the following warning in the console on start-up:
```
WARNING: You are currently running a version of TypeScript which is not officially supported by @typescript-eslint/typescript-estree.

You may find that it works just fine, or you may not.

SUPPORTED TYPESCRIPT VERSIONS: >=3.3.1 <5.1.0

YOUR TYPESCRIPT VERSION: 5.3.3

Please only submit bug reports when using the officially supported version.
```

And the culprit seems to be in this project.
```
$ npm ls @typescript-eslint/typescript-estree
opencast-editor@0.1.0 /home/arnewilken/IdeaProjects/opencast-editor
└─┬ @opencast/eslint-config-ts-react@0.1.0
  ├─┬ @typescript-eslint/eslint-plugin@5.40.0
  │ ├─┬ @typescript-eslint/type-utils@5.40.0
  │ │ └── @typescript-eslint/typescript-estree@5.40.0
  │ └─┬ @typescript-eslint/utils@5.40.0
  │   └── @typescript-eslint/typescript-estree@5.40.0 deduped
  └─┬ @typescript-eslint/parser@5.59.11
    └── @typescript-eslint/typescript-estree@5.59.11
    ```